### PR TITLE
[2.0][Feature] Dedup Key

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,7 @@ Enables you to add PagerDuty's advanced event and incident management functional
 
 Usage:
 ``` csharp
-var settings = new PagerDutySettings 
-{
-	RoutingKey = SERVICE_ROUTING_KEY
-};
+var settings = new PagerDutySettings { RoutingKey = SERVICE_ROUTING_KEY };
 
 var client = new PagerDutyClient(settings);
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,13 @@ Enables you to add PagerDuty's advanced event and incident management functional
 ### Send Event
 
 Usage:
-```
-var client = new PagerDutyClient("https://events.pagerduty.com", SERVICE_ROUTING_KEY, new HttpClient());
+``` csharp
+var settings = new PagerDutySettings 
+{
+	RoutingKey = SERVICE_ROUTING_KEY
+};
 
-await client.TriggerCriticalEventAsync("My service", EventAction.Trigger, Severity.Error, "Something went wrong!");
+var client = new PagerDutyClient(settings);
+
+await client.TriggerEventAsync(new EventTriggerOptions(Severity.Error, "My service", "Something went wrong!");
 ```

--- a/StoneCo.PagerDuty.Client.IntegrationTest/Test/PagerDutyClientTest.cs
+++ b/StoneCo.PagerDuty.Client.IntegrationTest/Test/PagerDutyClientTest.cs
@@ -1,4 +1,4 @@
-﻿using StoneCo.PagerDuty.Client.Settings;
+﻿using StoneCo.PagerDuty.Client.Contracts;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -7,61 +7,23 @@ namespace StoneCo.PagerDuty.Client.IntegrationTest.Test
     public class PagerDutyClientTest : IntegratedTestBase
     {
         private readonly IPagerDutyClient _pagerDutyClient;
-        private readonly PagerDutyClient _instancedPagerDutyClient;
 
         public PagerDutyClientTest()
         {
             _pagerDutyClient = Resolve<IPagerDutyClient>();
-
-            _instancedPagerDutyClient = new PagerDutyClient(Resolve<PagerDutySettings>());
         }
 
-        [Fact]
-        public async Task PageDutyClientTest_TriggerCriticalEventAsync_Should_Execute_Successfully()
+        [Theory]
+        [InlineData(Severity.Critical)]
+        [InlineData(Severity.Error)]
+        [InlineData(Severity.Info)]
+        [InlineData(Severity.Warning)]
+        public async Task GivenSeverity_ShouldTriggerSuccessfully(Severity severity)
         {
-            await _pagerDutyClient.TriggerCriticalEventAsync("PagerDuty.Client.IntegrationTest", "CriticalEvent");
-        }
+            const string source = "PagerDuty.Client.IntegrationTest";
+            const string summary = "TestEvent";
 
-        [Fact]
-        public async Task PageDutyClientTest_TriggerErrorEventAsync_Should_Execute_Successfully()
-        {
-            await _pagerDutyClient.TriggerErrorEventAsync("PagerDuty.Client.IntegrationTest", "ErrorEvent");
-        }
-
-        [Fact]
-        public async Task PageDutyClientTest_TriggerInfoEventAsync_Should_Execute_Successfully()
-        {
-            await _pagerDutyClient.TriggerInfoEventAsync("PagerDuty.Client.IntegrationTest", "InfoEvent");
-        }
-
-        [Fact]
-        public async Task PageDutyClientTest_TriggerWarningEventAsync_Should_Execute_Successfully()
-        {
-            await _pagerDutyClient.TriggerWarningEventAsync("PagerDuty.Client.IntegrationTest", "WarningEvent");
-        }
-
-        [Fact]
-        public async Task InstancedPageDutyClientTest_TriggerCriticalEventAsync_Should_Execute_Successfully()
-        {
-            await _instancedPagerDutyClient.TriggerCriticalEventAsync("PagerDuty.Client.IntegrationTest", "CriticalEvent");
-        }
-
-        [Fact]
-        public async Task InstancedPageDutyClientTest_TriggerErrorEventAsync_Should_Execute_Successfully()
-        {
-            await _instancedPagerDutyClient.TriggerErrorEventAsync("PagerDuty.Client.IntegrationTest", "ErrorEvent");
-        }
-
-        [Fact]
-        public async Task InstancedPageDutyClientTest_TriggerInfoEventAsync_Should_Execute_Successfully()
-        {
-            await _instancedPagerDutyClient.TriggerInfoEventAsync("PagerDuty.Client.IntegrationTest", "InfoEvent");
-        }
-
-        [Fact]
-        public async Task InstancedPageDutyClientTest_TriggerWarningEventAsync_Should_Execute_Successfully()
-        {
-            await _instancedPagerDutyClient.TriggerWarningEventAsync("PagerDuty.Client.IntegrationTest", "WarningEvent");
+            await _pagerDutyClient.TriggerEventAsync(new EventTriggerOptions(severity, source, summary));
         }
     }
 }

--- a/src/StoneCo.PagerDuty.Client/Contracts/SendEventRequest.cs
+++ b/src/StoneCo.PagerDuty.Client/Contracts/SendEventRequest.cs
@@ -5,14 +5,14 @@ namespace StoneCo.PagerDuty.Client.Contracts
 {
     internal class SendEventRequest
     {
-        public SendEventRequest(Payload payload, EventAction eventAction, string dedupKey)
+        public SendEventRequest(Payload payload, EventAction eventAction, string? dedupKey)
         {
             Payload = payload;
             EventAction = eventAction;
             DedupKey = dedupKey;
         }
 
-        public SendEventRequest(string source, EventAction eventAction, Severity severity, string summary, string dedupKey)
+        public SendEventRequest(string source, EventAction eventAction, Severity severity, string summary, string? dedupKey)
             : this(new Payload(source, summary, severity), eventAction, dedupKey)
         { }
 
@@ -24,6 +24,6 @@ namespace StoneCo.PagerDuty.Client.Contracts
         public Payload Payload { get; set; }
 
         [JsonProperty("dedup_key")]
-        public string DedupKey { get; set; }
+        public string? DedupKey { get; set; }
     }
 }

--- a/src/StoneCo.PagerDuty.Client/Contracts/SendEventRequest.cs
+++ b/src/StoneCo.PagerDuty.Client/Contracts/SendEventRequest.cs
@@ -5,14 +5,15 @@ namespace StoneCo.PagerDuty.Client.Contracts
 {
     internal class SendEventRequest
     {
-        public SendEventRequest(Payload payload, EventAction eventAction)
+        public SendEventRequest(Payload payload, EventAction eventAction, string dedupKey)
         {
             Payload = payload;
             EventAction = eventAction;
+            DedupKey = dedupKey;
         }
 
-        public SendEventRequest(string source, EventAction eventAction, Severity severity, string summary)
-            : this(new Payload(source, summary, severity), eventAction)
+        public SendEventRequest(string source, EventAction eventAction, Severity severity, string summary, string dedupKey)
+            : this(new Payload(source, summary, severity), eventAction, dedupKey)
         { }
 
         [JsonProperty("event_action")]
@@ -21,5 +22,8 @@ namespace StoneCo.PagerDuty.Client.Contracts
 
         [JsonProperty("payload")]
         public Payload Payload { get; set; }
+
+        [JsonProperty("dedup_key")]
+        public string DedupKey { get; set; }
     }
 }

--- a/src/StoneCo.PagerDuty.Client/Contracts/Severity.cs
+++ b/src/StoneCo.PagerDuty.Client/Contracts/Severity.cs
@@ -2,7 +2,7 @@
 
 namespace StoneCo.PagerDuty.Client.Contracts
 {
-    internal enum Severity
+    public enum Severity
     {
         [EnumMember(Value = "critical")] 
         Critical,

--- a/src/StoneCo.PagerDuty.Client/EventTriggerOptions.cs
+++ b/src/StoneCo.PagerDuty.Client/EventTriggerOptions.cs
@@ -1,0 +1,19 @@
+﻿using StoneCo.PagerDuty.Client.Contracts;
+
+namespace StoneCo.PagerDuty.Client
+{
+    public class EventTriggerOptions
+    {
+        public EventTriggerOptions(Severity severity, string source, string summary)
+        {
+            Source = source;
+            Summary = summary;
+            Severity = severity;
+        }
+
+        public Severity Severity { get; }
+        public string Source { get; set; }
+        public string Summary { get; set; }
+        public string? DedupKey { get; set; }
+    }
+}

--- a/src/StoneCo.PagerDuty.Client/IPagerDutyClient.cs
+++ b/src/StoneCo.PagerDuty.Client/IPagerDutyClient.cs
@@ -4,9 +4,6 @@ namespace StoneCo.PagerDuty.Client
 {
     public interface IPagerDutyClient
     {
-        Task TriggerCriticalEventAsync(string source, string summary, string dedupKey = null);
-        Task TriggerErrorEventAsync(string source, string summary, string dedupKey = null);
-        Task TriggerInfoEventAsync(string source, string summary, string dedupKey = null);
-        Task TriggerWarningEventAsync(string source, string summary, string dedupKey = null);
+        Task TriggerEventAsync(EventTriggerOptions options);
     }
 }

--- a/src/StoneCo.PagerDuty.Client/IPagerDutyClient.cs
+++ b/src/StoneCo.PagerDuty.Client/IPagerDutyClient.cs
@@ -4,9 +4,9 @@ namespace StoneCo.PagerDuty.Client
 {
     public interface IPagerDutyClient
     {
-        Task TriggerCriticalEventAsync(string source, string summary);
-        Task TriggerErrorEventAsync(string source, string summary);
-        Task TriggerInfoEventAsync(string source, string summary);
-        Task TriggerWarningEventAsync(string source, string summary);
+        Task TriggerCriticalEventAsync(string source, string summary, string dedupKey = null);
+        Task TriggerErrorEventAsync(string source, string summary, string dedupKey = null);
+        Task TriggerInfoEventAsync(string source, string summary, string dedupKey = null);
+        Task TriggerWarningEventAsync(string source, string summary, string dedupKey = null);
     }
 }

--- a/src/StoneCo.PagerDuty.Client/PagerDutyClient.cs
+++ b/src/StoneCo.PagerDuty.Client/PagerDutyClient.cs
@@ -46,8 +46,6 @@ namespace StoneCo.PagerDuty.Client
 
                 response = await _httpClient.PostAsync(SendEventEndpoint, request);
 
-                var content = await response.Content.ReadAsStringAsync();
-
                 response.EnsureSuccessStatusCode();
             }
             catch (System.Exception ex)

--- a/src/StoneCo.PagerDuty.Client/PagerDutyClient.cs
+++ b/src/StoneCo.PagerDuty.Client/PagerDutyClient.cs
@@ -4,7 +4,6 @@ using StoneCo.PagerDuty.Client.Exception;
 using StoneCo.PagerDuty.Client.Extension;
 using StoneCo.PagerDuty.Client.Settings;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Threading.Tasks;
 
 namespace StoneCo.PagerDuty.Client
@@ -28,9 +27,9 @@ namespace StoneCo.PagerDuty.Client
             PagerDutyDependenceExtension.ConfigureHttpClient(_httpClient, pagerDutySettings);
         }
 
-        private async Task Trigger(string source, string summary, EventAction action, Severity severity)
+        private async Task Trigger(string source, string summary, EventAction action, Severity severity, string dedupKey)
         {
-            await SendEvent(new SendEventRequest(source, action, severity, summary));
+            await SendEvent(new SendEventRequest(source, action, severity, summary, dedupKey));
         }
 
         private async Task SendEvent(SendEventRequest e)
@@ -54,16 +53,16 @@ namespace StoneCo.PagerDuty.Client
             }
         }
 
-        public Task TriggerCriticalEventAsync(string source, string summary) =>
-            Trigger(source, summary, EventAction.Trigger, Severity.Critical);
+        public Task TriggerCriticalEventAsync(string source, string summary, string dedupKey = null) =>
+            Trigger(source, summary, EventAction.Trigger, Severity.Critical,dedupKey);
 
-        public Task TriggerErrorEventAsync(string source, string summary) =>
-            Trigger(source, summary, EventAction.Trigger, Severity.Error);
+        public Task TriggerErrorEventAsync(string source, string summary, string dedupKey = null) =>
+            Trigger(source, summary, EventAction.Trigger, Severity.Error, dedupKey);
 
-        public Task TriggerInfoEventAsync(string source, string summary) =>
-            Trigger(source, summary, EventAction.Trigger, Severity.Info);
+        public Task TriggerInfoEventAsync(string source, string summary, string dedupKey = null) =>
+            Trigger(source, summary, EventAction.Trigger, Severity.Info, dedupKey);
 
-        public Task TriggerWarningEventAsync(string source, string summary) =>
-            Trigger(source, summary, EventAction.Trigger, Severity.Warning);
+        public Task TriggerWarningEventAsync(string source, string summary, string dedupKey = null) =>
+            Trigger(source, summary, EventAction.Trigger, Severity.Warning, dedupKey);
     }
 }

--- a/src/StoneCo.PagerDuty.Client/Settings/PagerDutySettings.cs
+++ b/src/StoneCo.PagerDuty.Client/Settings/PagerDutySettings.cs
@@ -2,7 +2,7 @@
 {
     public class PagerDutySettings
     {
-        public string BaseAddress { get; set; }
-        public string RoutingKey { get; set; }
+        public string? BaseAddress { get; set; } = "https://events.pagerduty.com";
+        public string? RoutingKey { get; set; }
     }
 }

--- a/src/StoneCo.PagerDuty.Client/StoneCo.PagerDuty.Client.csproj
+++ b/src/StoneCo.PagerDuty.Client/StoneCo.PagerDuty.Client.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>8</LangVersion>
     <Version>2.0.0</Version>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/StoneCo.PagerDuty.Client/StoneCo.PagerDuty.Client.csproj
+++ b/src/StoneCo.PagerDuty.Client/StoneCo.PagerDuty.Client.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>8</LangVersion>
-    <Version>1.2.0</Version>
+    <Version>2.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## História
[AB#168314](https://dev.azure.com/stonepagamentos/Fin-Payments/_workitems/edit/168314)

### Tarefas
[172060](https://dev.azure.com/stonepagamentos/Fin-Payments/_sprints/taskboard/Fin-Payments%20Team/Fin-Payments/Sprint%2031?workitem=172060)

## Adições
- Novo campo `DedupKey` para controle de mensagens duplicadas
- Nova classe `EventTriggerOptions`, para encapsular todos os campos que serão enviados através do `PagerDutyClient`

## Alterações
- Remoção dos método específicos de `Trigger` (Warning, Error, Info) para um único método `TriggerEventAsync`, que recebe um `EventTriggerOptions`, onde o campo `Severity` pode ser informado.
- README.md atualizado